### PR TITLE
Have recipe use HTTPS and simplify regex

### DIFF
--- a/Wacom/WacomTablet.download.recipe
+++ b/Wacom/WacomTablet.download.recipe
@@ -2,64 +2,64 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest version of Wacom Tablet drivers for macOS.</string>
-	<key>Identifier</key>
-	<string>com.github.rustymyers.download.WacomTablet</string>
-	<key>Input</key>
-	<dict>
-		<key>DOWNLOAD_PATTERN</key>
-		<string>(http:\/\/(?P&lt;url&gt;cdn\.wacom\.com\/u\/productsupport\/drivers\/mac\/professional\/WacomTablet_+(?P&lt;version&gt;[\d.-]+)\.dmg))</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://www.wacom.com/en-us/support/product-support/drivers</string>
-		<key>NAME</key>
-		<string>WacomTablet</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.4.0</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>%DOWNLOAD_PATTERN%</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>https://%url%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/Install Wacom Tablet.pkg</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: Wacom Technology Corp. (EG27766DY7)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-	</array>
+    <key>Description</key>
+    <string>Downloads the latest version of Wacom Tablet drivers for macOS.</string>
+    <key>Identifier</key>
+    <string>com.github.rustymyers.download.WacomTablet</string>
+    <key>Input</key>
+    <dict>
+        <key>DOWNLOAD_PATTERN</key>
+        <string>(http:\/\/(?P&lt;url&gt;cdn\.wacom\.com\/u\/productsupport\/drivers\/mac\/professional\/WacomTablet_+(?P&lt;version&gt;[\d.-]+)\.dmg))</string>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.wacom.com/en-us/support/product-support/drivers</string>
+        <key>NAME</key>
+        <string>WacomTablet</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>%DOWNLOAD_PATTERN%</string>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://%url%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Install Wacom Tablet.pkg</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Wacom Technology Corp. (EG27766DY7)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/Wacom/WacomTablet.download.recipe
+++ b/Wacom/WacomTablet.download.recipe
@@ -9,11 +9,11 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_PATTERN</key>
-		<string>(http://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_+(?P&lt;version&gt;[0-9].+[0-9].+[0-9]*-*[0-9]).dmg)</string>
+		<string>(http:\/\/(?P&lt;url&gt;cdn\.wacom\.com\/u\/productsupport\/drivers\/mac\/professional\/WacomTablet_+(?P&lt;version&gt;[\d.-]+)\.dmg))</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://www.wacom.com/en-us/support/product-support/drivers</string>
 		<key>NAME</key>
-		<string>Wacom Tablet</string>
+		<string>WacomTablet</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
@@ -36,7 +36,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%match%</string>
+				<string>https://%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Wanted to have the download be via HTTPS and simplify the regex pattern for Wacom's version structure.