### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/VineServer/VineServer.download.recipe
+++ b/VineServer/VineServer.download.recipe
@@ -49,7 +49,7 @@
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
                 <key>input_plist_path</key>
-                <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pathname%/Vine Server.app/Contents/Info.plist</string>
             </dict>
         </dict>
 		<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.