### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Microsoft/MSTeamsURLProvider.py
+++ b/Microsoft/MSTeamsURLProvider.py
@@ -17,9 +17,13 @@
 """See docstring for MSTeamsURLProvider class"""
 #import re
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["MSTeamsURLProvider"]
 
@@ -58,7 +62,7 @@ class MSTeamsURLProvider(Processor):
     def get_msteams_pkg_url(self, fetch_url):
         """Finds a download URL for latest MSTeams release"""
         try:
-            fref = urllib2.urlopen(fetch_url)
+            fref = urlopen(fetch_url)
             dl_url = fref.read()
             fref.close()
         except BaseException as err:

--- a/Microsoft/MSTeamsURLProvider.py
+++ b/Microsoft/MSTeamsURLProvider.py
@@ -65,7 +65,7 @@ class MSTeamsURLProvider(Processor):
             fref = urlopen(fetch_url)
             dl_url = fref.read()
             fref.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Could not retrieve %s: %s" %(fetch_url, err))
         # if the URL is empty, raise error
         if not dl_url:

--- a/Microsoft/MSTeamsURLProvider.py
+++ b/Microsoft/MSTeamsURLProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """See docstring for MSTeamsURLProvider class"""
 #import re
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/BoxDriveDownloadURLProvider.py
+++ b/SharedProcessors/BoxDriveDownloadURLProvider.py
@@ -10,9 +10,13 @@
 from __future__ import absolute_import
 import json
 import subprocess
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["BoxDriveDownloadURLProvider"]
 
@@ -57,7 +61,7 @@ class BoxDriveDownloadURLProvider(Processor):
 
     def get_json(self, url):
         try:
-            f = urllib2.urlopen(url)
+            f = urlopen(url)
             raw_json = f.read()
             f.close()
         except:

--- a/SharedProcessors/BoxDriveDownloadURLProvider.py
+++ b/SharedProcessors/BoxDriveDownloadURLProvider.py
@@ -8,6 +8,7 @@
 
 
 from __future__ import absolute_import
+
 import json
 import subprocess
 

--- a/SharedProcessors/BoxDriveDownloadURLProvider.py
+++ b/SharedProcessors/BoxDriveDownloadURLProvider.py
@@ -8,27 +8,23 @@
 
 
 from __future__ import absolute_import
-from __future__ import print_function
-import os
-import sys
-import subprocess
-import re
 import json
+import subprocess
+import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["BoxDriveDownloadURLProvider"]
 
 
 class BoxDriveDownloadURLProvider(Processor):
     '''Provides download URL for specific box drive installer from update json'''
-    
+
     description = "Provides download URL for Box Drive."
     input_variables = {
         'update_url': {
             "required": False,
-            "description": "URL for Box json",            
+            "description": "URL for Box json",
         },
         'os_type': {
             "required": True,
@@ -42,7 +38,7 @@ class BoxDriveDownloadURLProvider(Processor):
             "required": False,
             "description": "URL type to check for: rollout-url, download-url. Defaults to download-url",
         },
-            "CURL_PATH": {
+        "CURL_PATH": {
             "required": False,
             "default": "/usr/bin/curl",
             "description": "Path to curl binary. Defaults to /usr/bin/curl.",
@@ -53,22 +49,22 @@ class BoxDriveDownloadURLProvider(Processor):
             "description": "The url for the Box Drive download."
         },
         "version": {
-                "description": "The version reported from the json for requested download."
+            "description": "The version reported from the json for requested download."
         }
     }
 
     __doc__ = description
 
-    def get_json(self,url):
-		try:
-			f = urllib2.urlopen(url)
-			raw_json = f.read()
-			f.close()
-		except:
-			raise ProcessorError('Could not retrieve URL: "%s"' % url)
+    def get_json(self, url):
+        try:
+            f = urllib2.urlopen(url)
+            raw_json = f.read()
+            f.close()
+        except:
+            raise ProcessorError('Could not retrieve URL: "%s"' % url)
 
-		return json.loads(raw_json)
-        
+        return json.loads(raw_json)
+
     def fetch_content(self, url, headers=None):
         """Returns content retrieved by curl, given a url and an optional
         dictionary of header-name/value mappings. Logic here borrowed from
@@ -90,16 +86,16 @@ class BoxDriveDownloadURLProvider(Processor):
 
     def main(self):
 
-        default_box_json_url="https://cdn07.boxcdn.net/Autoupdate.json"
+        default_box_json_url = "https://cdn07.boxcdn.net/Autoupdate.json"
         os_type = self.env.get('os_type')
         release = self.env.get('release')
         update_url = self.env.get('update_url', default_box_json_url)
         url_type = self.env.get('url_type', 'download-url')
         verbosity = self.env.get('verbose', 0)
-        
+
         if verbosity > 1:
             self.output("Checking json for: {0}, {1}, {2} from {3}".format(os_type, release, url_type, update_url))
-            
+
         json_results = self.fetch_content(update_url)
 
         try:
@@ -107,8 +103,8 @@ class BoxDriveDownloadURLProvider(Processor):
         except:
             self.output("Failed to get %s, checking for download-url" % url_type)
             box_download_url = json_results[os_type][release]['download-url']
-        
-        print(box_download_url)
+
+        self.output(box_download_url)
         try:
             # Get the version associated with the download type
             if "rollout" in url_type:
@@ -117,7 +113,7 @@ class BoxDriveDownloadURLProvider(Processor):
                 box_version = json_results[os_type][release]["version"]
         except:
             box_version = json_results[os_type][release]["version"]
-            
+
 
         self.env['url'] = box_download_url
         self.env['version'] = box_version

--- a/SharedProcessors/BoxDriveDownloadURLProvider.py
+++ b/SharedProcessors/BoxDriveDownloadURLProvider.py
@@ -7,6 +7,8 @@
 # Based on WinInstallerExtractor
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -106,7 +108,7 @@ class BoxDriveDownloadURLProvider(Processor):
             self.output("Failed to get %s, checking for download-url" % url_type)
             box_download_url = json_results[os_type][release]['download-url']
         
-        print box_download_url
+        print(box_download_url)
         try:
             # Get the version associated with the download type
             if "rollout" in url_type:

--- a/SharedProcessors/FossHubURLProvider.py
+++ b/SharedProcessors/FossHubURLProvider.py
@@ -4,18 +4,12 @@
 #
 # Updated by Rusty Myers (rzm102@psu.edu)
 
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
-from __future__ import print_function
-import os
-import sys
-import subprocess
-import re
-import urllib2
 import json
+import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["FossHubURLProvider"]
 

--- a/SharedProcessors/FossHubURLProvider.py
+++ b/SharedProcessors/FossHubURLProvider.py
@@ -5,6 +5,8 @@
 # Updated by Rusty Myers (rzm102@psu.edu)
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -74,7 +76,7 @@ class FossHubURLProvider(Processor):
                 file_types.append(projectfile['type'])
         myset = set(file_types)
         for filetype in list(myset):
-            print filetype
+            print(filetype)
         
             
     def main(self):

--- a/SharedProcessors/FossHubURLProvider.py
+++ b/SharedProcessors/FossHubURLProvider.py
@@ -22,12 +22,12 @@ __all__ = ["FossHubURLProvider"]
 
 class FossHubURLProvider(Processor):
     '''Provides download URL for specific fosshub installer from projects json'''
-    
+
     description = "Provides download URL for Box Drive."
     input_variables = {
         'projects_url': {
             "required": False,
-            "description": "URL for Fosshub projects json",            
+            "description": "URL for Fosshub projects json",
         },
         'app_name': {
             "required": True,
@@ -61,13 +61,13 @@ class FossHubURLProvider(Processor):
         try:
             f = urllib2.urlopen(request)
             raw_json = f.read()
-            # print raw_json
+            # print(raw_json)
             f.close()
         except:
             raise ProcessorError('Could not retrieve projects URL "%s"' % url)
 
         return json.loads(raw_json)
-        
+
     def unique_types(self,json):
         file_types=[]
         # Return list of unique file types
@@ -77,18 +77,18 @@ class FossHubURLProvider(Processor):
         myset = set(file_types)
         for filetype in list(myset):
             print(filetype)
-        
-            
+
+
     def main(self):
         projects_url = self.env.get('projects_url', "https://university.fosshub.com/projects.json")
         app_name = self.env.get('app_name')
         app_type = self.env.get('app_type', "macOS DMG")
         verbosity = self.env.get('verbose', 0)
-        
-        
+
+
         if verbosity > 1:
             self.output("Checking json for: '{0}' & '{1}' from {2}".format(app_name, app_type, projects_url))
-            
+
         try:
             json_results = self.get_json(projects_url)
         except:
@@ -107,16 +107,16 @@ class FossHubURLProvider(Processor):
         for project in json_results['projects']:
             # If we find a project that matches
             if project['name'] == app_name:
-                # print project['name']
-                # print project
+                # print(project['name'])
+                # print(project)
                 # Check each file in the matched project
                 for projectfile in project['files']:
-                    # print projectfile
-                    # print projectfile['name']
-                    # print projectfile['downloadUrl']
-                    # print projectfile['version']
-                    # print projectfile['hashes']
-                    # print projectfile['type']
+                    # print(projectfile)
+                    # print(projectfile['name'])
+                    # print(projectfile['downloadUrl'])
+                    # print(projectfile['version'])
+                    # print(projectfile['hashes'])
+                    # print(projectfile['type'])
                     # If we match the app type in the project file
                     if projectfile['type'] == app_type:
                         # Return match if found

--- a/SharedProcessors/SourceForgeURLProvider.py
+++ b/SharedProcessors/SourceForgeURLProvider.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import datetime
-import re
-from xml.dom.minidom import parse, parseString
-import urllib2
 import json
+import re
+import urllib2
+from xml.dom.minidom import parse, parseString
 
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/SourceForgeURLProvider.py
+++ b/SharedProcessors/SourceForgeURLProvider.py
@@ -64,7 +64,7 @@ class SourceForgeURLProvider(Processor):
             f = urllib2.urlopen(flisturl)
             rss = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
 
         re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)

--- a/SharedProcessors/SourceForgeURLProvider.py
+++ b/SharedProcessors/SourceForgeURLProvider.py
@@ -15,95 +15,95 @@ FILE_INDEX_URL = 'http://sourceforge.net/api/file/index/project-id/%s/rss'
 PROJECT_NAME_URL = 'https://sourceforge.net/rest/p/%s'
 
 class SourceForgeURLProvider(Processor):
-	'''Provides URL to the latest file that matches a pattern for a particular SourceForge project.'''
+    '''Provides URL to the latest file that matches a pattern for a particular SourceForge project.'''
 
-	input_variables = {
-		'SOURCEFORGE_PROJECT_NAME': {
-			'required': False,
-			'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
-			},
-		'SOURCEFORGE_PROJECT_ID': {
-			'required': False,
-			'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
-			},
-		'SOURCEFORGE_FILE_PATTERN': {
-			'required': True,
-			'description': 'Pattern to match SourceFile files on',
-			},
-	}
-	output_variables = {
-		'url': {
-			'description': 'URL to the latest SourceForge project download'
-		}
-	}
+    input_variables = {
+        'SOURCEFORGE_PROJECT_NAME': {
+            'required': False,
+            'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
+            },
+        'SOURCEFORGE_PROJECT_ID': {
+            'required': False,
+            'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
+            },
+        'SOURCEFORGE_FILE_PATTERN': {
+            'required': True,
+            'description': 'Pattern to match SourceFile files on',
+            },
+    }
+    output_variables = {
+        'url': {
+            'description': 'URL to the latest SourceForge project download'
+        }
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def get_sf_project_id(self, pname):
-		# borrowed from https://gist.github.com/homebysix/9468859a76ac82f1d121
-		try:
-			f = urllib2.urlopen(PROJECT_NAME_URL % pname)
-			raw_json = f.read()
-			f.close()
-		except:
-			raise ProcessorError('Could not retrieve project name URL for "%s"' % pname)
+    def get_sf_project_id(self, pname):
+        # borrowed from https://gist.github.com/homebysix/9468859a76ac82f1d121
+        try:
+            f = urllib2.urlopen(PROJECT_NAME_URL % pname)
+            raw_json = f.read()
+            f.close()
+        except:
+            raise ProcessorError('Could not retrieve project name URL for "%s"' % pname)
 
-		parsed_json = json.loads(raw_json)
+        parsed_json = json.loads(raw_json)
 
-		for tools in parsed_json['tools']:
-			try:
-				return tools['sourceforge_group_id']
-			except KeyError:
-				pass
+        for tools in parsed_json['tools']:
+            try:
+                return tools['sourceforge_group_id']
+            except KeyError:
+                pass
 
-	def get_sf_file_url(self, proj_id, pattern):
-		flisturl = FILE_INDEX_URL % proj_id
+    def get_sf_file_url(self, proj_id, pattern):
+        flisturl = FILE_INDEX_URL % proj_id
 
-		try:
-			f = urllib2.urlopen(flisturl)
-			rss = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
+        try:
+            f = urllib2.urlopen(flisturl)
+            rss = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
 
-		re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)
+        re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)
 
-		rss_parse = parseString(rss)
+        rss_parse = parseString(rss)
 
-		items = []
+        items = []
 
-		for i in  rss_parse.getElementsByTagName('item'):
-			pubDate = i.getElementsByTagName('pubDate')[0].firstChild.nodeValue
-			link = i.getElementsByTagName('link')[0].firstChild.nodeValue
+        for i in  rss_parse.getElementsByTagName('item'):
+            pubDate = i.getElementsByTagName('pubDate')[0].firstChild.nodeValue
+            link = i.getElementsByTagName('link')[0].firstChild.nodeValue
 
-			pubDatetime = datetime.datetime.strptime(pubDate, '%a, %d %b %Y %H:%M:%S UT')
+            pubDatetime = datetime.datetime.strptime(pubDate, '%a, %d %b %Y %H:%M:%S UT')
 
-			if re_file.search(link):
-				items.append((pubDatetime, link),)
+            if re_file.search(link):
+                items.append((pubDatetime, link),)
 
-		items.sort(key=lambda r: r[0])
+        items.sort(key=lambda r: r[0])
 
-		if len(items) < 1:
-			raise ProcessorError('No matched files')
+        if len(items) < 1:
+            raise ProcessorError('No matched files')
 
-		return items[-1][1]
+        return items[-1][1]
 
-	def main(self):
-		proj_name = self.env.get('SOURCEFORGE_PROJECT_NAME')
-		proj_id  = self.env.get('SOURCEFORGE_PROJECT_ID')
-		file_pat = self.env.get('SOURCEFORGE_FILE_PATTERN')
+    def main(self):
+        proj_name = self.env.get('SOURCEFORGE_PROJECT_NAME')
+        proj_id  = self.env.get('SOURCEFORGE_PROJECT_ID')
+        file_pat = self.env.get('SOURCEFORGE_FILE_PATTERN')
 
-		if not proj_id:
-			if not proj_name:
-				raise ProcessorError('One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.')
+        if not proj_id:
+            if not proj_name:
+                raise ProcessorError('One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.')
 
-			proj_id = self.get_sf_project_id(proj_name)
-			self.output('Found SourceForge project ID %s for %s' % (proj_id, proj_name))
+            proj_id = self.get_sf_project_id(proj_name)
+            self.output('Found SourceForge project ID %s for %s' % (proj_id, proj_name))
 
 
-		self.env['url'] = self.get_sf_file_url(proj_id, file_pat)
-		self.output('File URL %s' % self.env['url'])
+        self.env['url'] = self.get_sf_file_url(proj_id, file_pat)
+        self.output('File URL %s' % self.env['url'])
 
 if __name__ == '__main__':
-	processor = SourceForgeURLProvider()
-	processor.execute_shell()
+    processor = SourceForgeURLProvider()
+    processor.execute_shell()

--- a/SharedProcessors/SourceForgeURLProvider.py
+++ b/SharedProcessors/SourceForgeURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import datetime
 import re
 from xml.dom.minidom import parse, parseString


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including handling HTTP headers), but this should catch the low-hanging fruit right now.