### PR TITLE
Remove unused BUNDLE_ID input var and fix SolsticeUSB app name

### DIFF
--- a/Mersive/SolsticeUSB.download.recipe
+++ b/Mersive/SolsticeUSB.download.recipe
@@ -71,7 +71,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/usb_Solstice Client.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/usb_Mersive Solstice.app</string>
                 <key>target</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Solstice Client.app</string>
             </dict>

--- a/Mersive/SolsticeUSB.pkg.recipe
+++ b/Mersive/SolsticeUSB.pkg.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>SolsticeClientMacWeb</string>
-		<key>BUNDLE_ID</key>
-		<string>com.mersive.solstice.client</string>
 		<key>NAME</key>
 		<string>Solstice</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

The app name for SolsticeUSB has also been updated.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types).

## ✅ Mersive/SolsticeUSB.download.recipe

```
% /usr/local/bin/autopkg run -vvq repos/rustymyers-recipes/Mersive/SolsticeUSB.download.recipe
Processing repos/rustymyers-recipes/Mersive/SolsticeUSB.download.recipe...
URLTextSearcher
{'Input': {'re_pattern': '((www.mersive.com\\/downloads\\/SolsticeClientMac-([0-9]{0,5}.){0,3})tgz)',
           'url': 'https://www.mersive.com/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz
{'Output': {'match': 'www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz'}}
URLDownloader
{'Input': {'filename': 'Solstice.tar',
           'url': 'https://www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 13 Jan 2021 00:56:45 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/downloads/Solstice.tar
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 13 Jan 2021 00:56:45 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/downloads/Solstice.tar',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/downloads/Solstice.tar'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Unarchiver
{'Input': {'archive_format': 'tar_gzip', 'purge_destination': True}}
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/downloads/Solstice.tar to ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice
{'Output': {}}
FileMover
{'Input': {'source': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/usb_Mersive '
                     'Solstice.app',
           'target': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice '
                     'Client.app'}}
FileMover: File ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/usb_Mersive Solstice.app moved to ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice Client.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice '
                               'Client.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 5.2.25530 in file ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice Client.app/Contents/Info.plist
{'Output': {'version': '5.2.25530'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice '
                         'Client.app',
           'requirement': 'identifier "com.mersive.solstice.client" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"63B5A5WDNG"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice Client.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/Solstice/Solstice Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/receipts/SolsticeUSB.download-receipt-20210213-221732.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    ~/Library/AutoPkg/Cache/com.github.rustymyers.download.SolsticeUSB/downloads/Solstice.tar  
```

## ✅ Mersive/SolsticeUSB.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/rustymyers-recipes/Mersive/SolsticeUSB.pkg.recipe
Processing repos/rustymyers-recipes/Mersive/SolsticeUSB.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '((www.mersive.com\\/downloads\\/SolsticeClientMac-([0-9]{0,5}.){0,3})tgz)',
           'url': 'https://www.mersive.com/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz
{'Output': {'match': 'www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz'}}
URLDownloader
{'Input': {'filename': 'Solstice.tar',
           'url': 'https://www.mersive.com/downloads/SolsticeClientMac-5.2.1.tgz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/downloads/Solstice.tar
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/downloads/Solstice.tar'}}
Unarchiver
{'Input': {'archive_format': 'tar_gzip', 'purge_destination': True}}
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/downloads/Solstice.tar to ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice
{'Output': {}}
FileMover
{'Input': {'source': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/usb_Mersive '
                     'Solstice.app',
           'target': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice '
                     'Client.app'}}
FileMover: File ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/usb_Mersive Solstice.app moved to ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice '
                               'Client.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 5.2.25530 in file ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app/Contents/Info.plist
{'Output': {'version': '5.2.25530'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice '
                         'Client.app',
           'requirement': 'identifier "com.mersive.solstice.client" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"63B5A5WDNG"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice '
                       'Client.app',
           'version': '5.2.25530'}}
AppPkgCreator: BundleID: com.mersive.solstice.client
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice/Solstice Client.app to ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/payload/Applications/Solstice Client.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.mersive.solstice.client',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice '
                                                                    'Client-5.2.25530.pkg',
                                                        'version': '5.2.25530'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.2.25530'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/receipts/SolsticeUSB.pkg-receipt-20210213-221757.plist

The following packages were built:
    Identifier                   Version    Pkg Path                                                                                                  
    ----------                   -------    --------                                                                                                  
    com.mersive.solstice.client  5.2.25530  ~/Library/AutoPkg/Cache/com.github.rustymyers.pkg.SolsticeUSB/Solstice Client-5.2.25530.pkg  
```

