### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/Microsoft/MSdotNetFramework-Win.download.recipe
+++ b/Microsoft/MSdotNetFramework-Win.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>.Net Framework</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>Process</key>
 	<array>

--- a/Microsoft/MSdotNetFramework.download.recipe
+++ b/Microsoft/MSdotNetFramework.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>.Net Framework</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.