### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/SharedProcessors/BoxDriveDownloadURLProvider.py
+++ b/SharedProcessors/BoxDriveDownloadURLProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2018 The Pennsylvania State University.
 #
@@ -22,8 +22,14 @@ class BoxDriveDownloadURLProvider(URLGetter):
 
     description = "Provides download URL for Box Drive."
     input_variables = {
-        "update_url": {"required": False, "description": "URL for Box json",},
-        "os_type": {"required": True, "description": "os_type: mac, win, win32",},
+        "update_url": {
+            "required": False,
+            "description": "URL for Box json",
+        },
+        "os_type": {
+            "required": True,
+            "description": "os_type: mac, win, win32",
+        },
         "release": {
             "required": True,
             "description": "Release to check for: alpha, beta, enterprise, free, eap",

--- a/SharedProcessors/FossHubURLProvider.py
+++ b/SharedProcessors/FossHubURLProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2018 The Pennsylvania State University.
 #
@@ -22,7 +22,10 @@ class FossHubURLProvider(URLGetter):
             "required": False,
             "description": "URL for FossHub projects json",
         },
-        "app_name": {"required": True, "description": "Name of FossHub app",},
+        "app_name": {
+            "required": True,
+            "description": "Name of FossHub app",
+        },
         "app_type": {
             "required": False,
             "description": "Type of installer prefered, defaults to dmg",


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.