### PR TITLE
Adjust VineServer recipe to download from SourceForge

### DIFF
--- a/VineServer/VineServer.download.recipe
+++ b/VineServer/VineServer.download.recipe
@@ -6,35 +6,31 @@
 	<string>com.github.rustymyers.download.VineServer</string>
 	<key>Input</key>
 	<dict>
-        <key>BIGFIXNAME</key>
-        <string>VineServer</string>
-        <key>NAME</key>
-        <string>Vine Server</string>
-    	<key>Description</key>
-    	<string>Downloads the latest version of Vine Server.</string>
-        <key>SEARCH_PATTERN</key>
-        <string>http.*VineServer[0-9].[0-9][0-9]\.dmg</string>
+		<key>BIGFIXNAME</key>
+		<string>VineServer</string>
+		<key>Description</key>
+		<string>Downloads the latest version of Vine Server.</string>
+		<key>NAME</key>
+		<string>Vine Server</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://www.testplant.com/dlds/vine/</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
-        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%match%</string>
+				<key>SOURCEFORGE_FILE_PATTERN</key>
+				<string>\.dmg</string>
+				<key>SOURCEFORGE_PROJECT_NAME</key>
+				<string>osxvnc</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%BIGFIXNAME%.dmg</string>
 			</dict>
@@ -42,16 +38,16 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-                <key>input_plist_path</key>
-                <string>%pathname%/Vine Server.app/Contents/Info.plist</string>
-            </dict>
-        </dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Vine Server.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>


### PR DESCRIPTION
This PR adjusts the VineServer recipe to download from SourceForge, since the software is no longer available on the TestPlant website.

Verbose recipe run output:

```
% autopkg run -vvq '~/Developer/repo-lasso/repos/autopkg/rustymyers-recipes/VineServer/VineServer.download.recipe'
Processing ~/Developer/repo-lasso/repos/autopkg/rustymyers-recipes/VineServer/VineServer.download.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/rustymyers-recipes/VineServer/VineServer.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': '\\.dmg',
           'SOURCEFORGE_PROJECT_NAME': 'osxvnc'}}
SourceForgeURLProvider: Found SourceForge project ID 64523 for osxvnc
SourceForgeURLProvider: File URL https://sourceforge.net/projects/osxvnc/files/Vine%20Server%28OSXvnc%29/Version%203.0/VineServer3.0.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/osxvnc/files/Vine%20Server%28OSXvnc%29/Version%203.0/VineServer3.0.dmg/download'}}
URLDownloader
{'Input': {'filename': 'VineServer.dmg',
           'url': 'https://sourceforge.net/projects/osxvnc/files/Vine%20Server%28OSXvnc%29/Version%203.0/VineServer3.0.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 21 Dec 2007 20:20:17 GMT
URLDownloader: Storing new ETag header: "476c2001-17e0cd"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg
{'Output': {'download_changed': True,
            'etag': '"476c2001-17e0cd"',
            'last_modified': 'Fri, 21 Dec 2007 20:20:17 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg/Vine '
                               'Server.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg
Versioner: Found version 3.0 in file ~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg/Vine Server.app/Contents/Info.plist
{'Output': {'version': '3.0'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/receipts/VineServer.download-receipt-20241230-124816.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rustymyers.download.VineServer/downloads/VineServer.dmg
```
