### PR TITLE
Deprecate Audacity ARM download recipe

### DIFF
--- a/Audacity/Audacity-arm.download.recipe
+++ b/Audacity/Audacity-arm.download.recipe
@@ -17,9 +17,18 @@ Note: the Audacity.app code object is not signed at all.</string>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Audacity recipe no longer maintained. Switching to using: com.github.ahousseini-recipes.pkg.Audacity</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>com.github.rustymyers.SharedProcessors/FossHubURLProvider</string>

--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -15,18 +15,18 @@ Note: the Audacity.app code object is not signed at all.</string>
         <string>Audacity</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>warning_message</key>
-				<string>Audacity recipe no longer maintained. Switching to using: com.github.ahousseini-recipes.pkg.Audacity</string>
-			</dict>
-			<key>Processor</key>
-			<string>DeprecationWarning</string>
-		</dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Audacity recipe no longer maintained. Switching to using: com.github.ahousseini-recipes.pkg.Audacity</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR copies the deprecation message from Audacity.download to Audacity-ARM.download to ensure all users get a chance to see the warning before the recipe is removed.

Minor: DeprecationWarning requires AutoPkg 1.1 so MinimumVersion has been bumped as well.