### PR TITLE
MinimumVersion, EndOfCheckPhase, and NAME variable best practices

### DIFF
--- a/EnergyPlus/EnergyPlus.download.recipe
+++ b/EnergyPlus/EnergyPlus.download.recipe
@@ -40,6 +40,10 @@
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/EnergyPlus/EnergyPlus.download.recipe
+++ b/EnergyPlus/EnergyPlus.download.recipe
@@ -22,7 +22,7 @@
         <string>dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/EnergyPlus/EnergyPlus.download.recipe
+++ b/EnergyPlus/EnergyPlus.download.recipe
@@ -3,13 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download latest EnergyPlus.</string>
+    <string>Download latest EnergyPlus.
+    
+Defaults to x86_64, pass arm64 to ARCH for Apple Silicon or arm for Linux
+OS can be Windows, macOS, Ubuntu, CentOS
+osVersion should be nothing for Windows, (10/11/12) for macOS  and linux version  for each distro
+EXT can be (zip/exe) for Windows, (dmg/tar.gz) for macOS and (run/sh/tar.gz) for linux
+</string>
     <key>Identifier</key>
     <string>com.github.rustymyers.download.EnergyPlus</string>
-    <!-- Defaults to x86_64, pass arm64 to ARCH for Apple Silicon or arm for Linux -->
-    <!-- OS can be Windows, macOS, Ubuntu, CentOS -->
-    <!-- osVersion should be nothing for Windows, (10/11/12) for macOS  and linux version  for each distro -->
-    <!-- EXT can be (zip/exe) for Windows, (dmg/tar.gz) for macOS and (run/sh/tar.gz) for linux -->
     <key>Input</key>
     <dict>
         <key>ARCH</key>

--- a/Git/Git-Win64.download.recipe.yaml
+++ b/Git/Git-Win64.download.recipe.yaml
@@ -17,3 +17,4 @@ Process:
   - Processor: URLDownloader
     Arguments:
       filename: "%NAME%-%version_exe%.exe"
+  - Processor: EndOfCheckPhase

--- a/Linden Lab/SecondLife.download.recipe
+++ b/Linden Lab/SecondLife.download.recipe
@@ -12,7 +12,7 @@
         <string>SecondLife</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/LoginLog/LoginLog.pkg.recipe
+++ b/LoginLog/LoginLog.pkg.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>app_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/LoginLog.app</string>
             </dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>
@@ -48,9 +48,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/*%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/*LoginLog.app</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PrivilegedHelperTools/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PrivilegedHelperTools/LoginLog.app</string>
             </dict>
         </dict>
         <dict>

--- a/Microsoft/MSdotNetFramework-Win.download.recipe
+++ b/Microsoft/MSdotNetFramework-Win.download.recipe
@@ -74,6 +74,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Microsoft/MSdotNetFramework.download.recipe
+++ b/Microsoft/MSdotNetFramework.download.recipe
@@ -74,6 +74,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Sawgrass/SawgrassPrintManager.pkg.recipe
+++ b/Sawgrass/SawgrassPrintManager.pkg.recipe
@@ -62,6 +62,17 @@
             <key>Processor</key>
             <string>PathDeleter</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_pkg</key>
+                <string>%pathname%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Sawgrass/SawgrassPrintManager.pkg.recipe
+++ b/Sawgrass/SawgrassPrintManager.pkg.recipe
@@ -18,10 +18,6 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
            <key>Processor</key>
             <string>FlatPkgUnpacker</string>
             <key>Arguments</key>

--- a/Veusz/Veusz.pkg.recipe
+++ b/Veusz/Veusz.pkg.recipe
@@ -12,7 +12,7 @@
 		<string>Veusz</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rustymyers.download.Veusz</string>
 	<key>Process</key>

--- a/Wacom/WacomBamboo-Win.download.recipe
+++ b/Wacom/WacomBamboo-Win.download.recipe
@@ -16,7 +16,7 @@
 		<string>Wacom Bamboo Driver Windows</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Wacom/WacomIntuos-Win.download.recipe
+++ b/Wacom/WacomIntuos-Win.download.recipe
@@ -16,7 +16,7 @@
 		<string>Wacom Intuos Driver Windows</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Wepa/Wepa.download.recipe
+++ b/Wepa/Wepa.download.recipe
@@ -12,7 +12,7 @@
             <string>Wepa Print App</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.9</string>
+        <string>0.3.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/Wepa/WepaLargeFormat.download.recipe
+++ b/Wepa/WepaLargeFormat.download.recipe
@@ -12,7 +12,7 @@
             <string>Wepa Large Format</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.9</string>
+        <string>0.3.1</string>
         <key>Process</key>
         <array>
             <dict>


### PR DESCRIPTION
This PR includes these minor changes to recipes:

- Increase MinimumVersion (of AutoPkg) required based on actual processors used in each recipe
- Ensure EndOfCheckPhase is after the download process, and not in other places
- Add PkgCopier to pkg recipes that don't take other package creation actions
- Use actual app name instead of NAME in paths where overriding the name would otherwise break the recipe