### PR TITLE
Second Life Downloader: regex works for grabbing installer dmg link

### DIFF
--- a/Linden Lab/SecondLife.download.recipe.yaml
+++ b/Linden Lab/SecondLife.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
 Process:
 - Processor: URLTextSearcher
   Arguments:
-    re_pattern: a href=.?(?P<url>http.*?Second_Life.*?\.dmg)
+    re_pattern: \\u003e(?P<url>https://viewer.+?Second_Life.*?\.dmg)
     url: https://secondlife.com/support/downloads/
 
 - Processor: URLDownloader


### PR DESCRIPTION
Second Life downloader's regex needed TLC.