### PR TITLE
Hash changed, autopkg run failing

### DIFF
--- a/Veusz/Veusz.download.recipe.yaml
+++ b/Veusz/Veusz.download.recipe.yaml
@@ -22,6 +22,6 @@ Process:
 - Processor: CodeSignatureVerifier
   Arguments:
     input_path: '%pathname%/Veusz.app'
-    requirement: cdhash H"d50366772163beb7f32da37bec9602424e6cd9e7"
+    requirement: cdhash H"c3e52db68980c9fb619d4eba87c48eb073c33983"
 
 - Processor: EndOfCheckPhase


### PR DESCRIPTION
code signature verifier failing.  
Output of downloaded app:
codesign -dv --verbose=4 /Volumes/Veusz\ 4.1/Veusz.app  Executable=/Volumes/Veusz 4.1/Veusz.app/Contents/MacOS/veusz.exe Identifier=Veusz
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=111070 flags=0x2(adhoc) hashes=3465+3 location=embedded VersionPlatform=1
VersionMin=720896
VersionSDK=918784
Hash type=sha256 size=32
CandidateCDHash sha256=c3e52db68980c9fb619d4eba87c48eb073c33983 CandidateCDHashFull sha256=c3e52db68980c9fb619d4eba87c48eb073c3398388f9d43e90d55e4868207296 Hash choices=sha256
CMSDigest=c3e52db68980c9fb619d4eba87c48eb073c3398388f9d43e90d55e4868207296 CMSDigestType=2
Executable Segment base=0
Executable Segment limit=49152
Executable Segment flags=0x1
Page size=4096
CDHash=c3e52db68980c9fb619d4eba87c48eb073c33983
Signature=adhoc
Info.plist entries=12
TeamIdentifier=not set
Sealed Resources version=2 rules=13 files=1100
Internal requirements count=0 size=12