### PR TITLE
Fix DOWNLOAD_PATTERN regex for WacomTablet driver URL

### DIFF
--- a/Wacom/WacomTablet.download.recipe.yaml
+++ b/Wacom/WacomTablet.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: 0.4.0
 
 Input:
   NAME: WacomTablet
-  DOWNLOAD_PATTERN: (?P<url>(https:\/\/cdn\.wacom\.com\/u\/productsupport\/drivers\/mac\/professional\/WacomTablet_+(?P<version>([\d].)+(\d))\.dmg))
+  DOWNLOAD_PATTERN: (?P<url>(https:\/\/cdn\.wacom\.com\/u\/productsupport\/drivers\/mac\/professional\/WacomTablet_(?P<version>\d+(?:\.\d+)*(?:-\d+)?)\.dmg))
   DOWNLOAD_URL: https://www.wacom.com/en-us/support/product-support/drivers
 
 Process:


### PR DESCRIPTION
### Description
Wacom recently changed their driver versioning scheme to include a hyphen (e.g. 6.4.10-3). The existing regex pattern did not account for this, causing the download URL to go unmatched.

### Change
Updated the regex to allow hyphens (and other valid characters) in the version capture group.

### Impact
The regex now correctly captures URLs with both old (6.4.10) and new (6.4.10-3) version formats.